### PR TITLE
add: gitignore .DS_Store 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea
 *.iml
 out
+.DS_Store


### PR DESCRIPTION
### gitignore에 .DS_Store 추가
맥OS에서 자동으로 생성되는 .DS_Store는 제외하기 위해 gitignore에 추가했습니다.